### PR TITLE
Use official docstore API in BM25 retriever creation

### DIFF
--- a/retriever_factory.py
+++ b/retriever_factory.py
@@ -85,7 +85,11 @@ def create_advanced_retriever(
     )
 
     # --- 3. Prepara os retrievers base ---
-    all_chunks = list(vector_store.docstore._dict.values())
+    # Coleta os documentos sem acessar atributos privados do docstore
+    all_chunks = [
+        vector_store.docstore.search(doc_id)
+        for doc_id in vector_store.index_to_docstore_id.values()
+    ]
     if not all_chunks:
         raise ValueError(
             "Nenhum documento encontrado no docstore do FAISS. O índice pode estar vazio."
@@ -107,6 +111,7 @@ def create_advanced_retriever(
             "Biblioteca de re-ranking indisponível; retornando retriever híbrido sem re-ranking."
         )
         return ensemble_retriever
+
 
     try:
         reranker_model_name = retriever_config.get(


### PR DESCRIPTION
## Summary
- Avoid direct access to FAISS docstore internals when gathering documents
- Build BM25 retriever using documents fetched via `index_to_docstore_id` and `docstore.search`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0af24b220832f9ea50d4f24697d08