### PR TITLE
Use rank-bm25 package

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,5 +8,5 @@ sentence-transformers
 faiss-cpu
 pymupdf
 python-dotenv
-rank_bm25
+rank-bm25
 langchain-experimental


### PR DESCRIPTION
## Summary
- replace deprecated rank_bm25 dependency with rank-bm25

## Testing
- `pytest`
- `pip-compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0be4d0e84832f8be9059cce8d2f7b