### PR TITLE
Remove unused FAISS and embedding imports

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,7 +1,5 @@
 import logging
 from logger_config import setup_logging
-from langchain_community.vectorstores import FAISS
-from langchain_community.embeddings import SentenceTransformerEmbeddings
 from langchain_openai import ChatOpenAI
 from langchain.agents import tool, AgentExecutor, create_openai_tools_agent
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder


### PR DESCRIPTION
## Summary
- remove unused FAISS and SentenceTransformerEmbeddings imports from agent

## Testing
- `flake8 agent.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0bf455c74832fa74ce6feb5a783b0