### PR TITLE
Configure logging during agent import

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -7,6 +7,9 @@ from dotenv import load_dotenv
 import yaml
 from retriever_factory import create_advanced_retriever
 
+# Configure logging as soon as the module is imported
+setup_logging()
+
 load_dotenv()
 
 with open('config.yaml', 'r', encoding='utf-8') as f:
@@ -119,8 +122,6 @@ def create_rag_agent():
 
 if __name__ == '__main__':
 
-    setup_logging()
-    
     rag_agent = create_rag_agent()
     logging.info("Agente RAG iniciado. Faça suas perguntas. Pressione Ctrl+C para sair.")
 


### PR DESCRIPTION
## Summary
- Initialize logging once when `agent.py` is imported by calling `setup_logging()` immediately after imports.
- Avoid duplicate logging configuration by removing `setup_logging()` from the main execution block.

## Testing
- `python -m py_compile agent.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cbf563d8832f85f98d5a578f6e15